### PR TITLE
Apply pacakge-lint suggestions

### DIFF
--- a/org-onit.el
+++ b/org-onit.el
@@ -54,8 +54,8 @@
 ;;; Code:
 
 (require 'org-clock)
-(when (require 'bookmark nil t)
-  (bookmark-maybe-load-default-file))
+(require 'bookmark nil t)
+(bookmark-maybe-load-default-file)
 
 (defgroup org-onit nil
   "Commands to toggle `org-clock-in' and `org-clock-out'."
@@ -168,6 +168,7 @@ This flag is utilized for `org-onit-toggle-auto'."
               (list (car list)))
     list))
 
+(defvar org-onit-mode)
 (defvar org-onit--auto-clocking nil)
 (defvar org-onit--heading nil)
 (defvar org-onit--state nil)
@@ -290,7 +291,7 @@ SELECT is the optional argument of `org-clock-goto'."
       (org-onit--bookmark-jump org-onit-bookmark)) ;; call org-bookmark-jump
      (org-clock-history
       (apply f select)
-      (show-children))
+      (outline-show-children))
      (bm
       (org-onit--bookmark-jump org-onit-bookmark)) ;; use normal bookmark
      (t (message "No clock is found to be shown")))))
@@ -433,7 +434,7 @@ Unprovided property will not change the original value."
            (remove-hook 'post-command-hook #'org-onit--post-action)
            (org-onit--clock-out)
            (run-hooks 'org-onit-stop-autoclock-hook)))
-    (redraw-modeline)))
+    (force-mode-line-update)))
 
 ;;;###autoload
 (defun org-onit-toggle-doing ()

--- a/org-onit.el
+++ b/org-onit.el
@@ -290,7 +290,7 @@ SELECT is the optional argument of `org-clock-goto'."
       (org-onit--bookmark-jump org-onit-bookmark)) ;; call org-bookmark-jump
      (org-clock-history
       (apply f select)
-      (outline-show-children))
+      (org-show-children))
      (bm
       (org-onit--bookmark-jump org-onit-bookmark)) ;; use normal bookmark
      (t (message "No clock is found to be shown")))))

--- a/org-onit.el
+++ b/org-onit.el
@@ -158,6 +158,47 @@ This flag is utilized for `org-onit-toggle-auto'."
   :group 'org-onit)
 (make-obsolete-variable 'org-onit-use-unfold-as-doing 'org-onit-basic-options "1.2.0")
 
+;;;###autoload
+(define-minor-mode org-onit-mode
+  "
+This minor mode expands `org-clock-in', `org-clock-out' and `org-clock-goto'
+to support \"Doing\" functionality. When you toggle a heading, a clock for
+the heading is automatically activated and the heading is tagged with
+`org-doing-tag'. Toggling the same heading, the clock is stopped, and the tag
+is removed. Basically, a single heading tagged with `org-doing-tag' will
+appear in org buffers.
+
+The tagged heading can be easily revisited by calling the extended
+`org-clock-goto' command whether you are editing another heading in any
+org buffers.
+
+An automated `org-clock-in' capability is also provided by this package.
+A heading that you are currently visiting in an org buffer will be
+automatically clocked with executing `org-clock-in'. After you switch to
+other headings, the active clock will be automatically updated without any
+additional actions.
+
+Recommended settings for `org-clock':
+  (setq org-clock-out-remove-zero-time-clocks t) ;; you should apply this.
+  (setq org-clock-clocked-in-display 'frame-title) ;; or 'both
+  (setq org-clock-frame-title-format
+    '((:eval (format \"%s\" org-mode-line-string))))
+
+Recommended keybindings:
+  (global-set-key (kbd \"C-<f11>\") 'org-clock-goto)
+  (define-key org-mode-map (kbd \"<f11>\") 'org-onit-toggle-doing)
+  (define-key org-mode-map (kbd \"M-<f11>\") 'org-onit-toggle-auto)
+  (define-key org-mode-map (kbd \"S-<f11>\") 'org-onit-goto-anchor)
+"
+  :init-value nil
+  :lighter (:eval (org-onit--lighter))
+  :require 'org-clock
+  :group 'org-onit
+  (if org-onit-mode
+      (org-onit--setup)
+    (org-onit--abort)))
+
+
 ;; internal functions
 
 (defun org-onit--rotate-list (list)
@@ -167,7 +208,6 @@ This flag is utilized for `org-onit-toggle-auto'."
               (list (car list)))
     list))
 
-(defvar org-onit-mode)
 (defvar org-onit--auto-clocking nil)
 (defvar org-onit--heading nil)
 (defvar org-onit--state nil)
@@ -485,46 +525,6 @@ STATE should be one of the symbols listed in the docstring of
     (org-onit--clock-in)
     (org-cycle-hide-drawers 'children)
     (org-reveal)))
-
-;;;###autoload
-(define-minor-mode org-onit-mode
-  "
-This minor mode expands `org-clock-in', `org-clock-out' and `org-clock-goto'
-to support \"Doing\" functionality. When you toggle a heading, a clock for
-the heading is automatically activated and the heading is tagged with
-`org-doing-tag'. Toggling the same heading, the clock is stopped, and the tag
-is removed. Basically, a single heading tagged with `org-doing-tag' will
-appear in org buffers.
-
-The tagged heading can be easily revisited by calling the extended
-`org-clock-goto' command whether you are editing another heading in any
-org buffers.
-
-An automated `org-clock-in' capability is also provided by this package.
-A heading that you are currently visiting in an org buffer will be
-automatically clocked with executing `org-clock-in'. After you switch to
-other headings, the active clock will be automatically updated without any
-additional actions.
-
-Recommended settings for `org-clock':
-  (setq org-clock-out-remove-zero-time-clocks t) ;; you should apply this.
-  (setq org-clock-clocked-in-display 'frame-title) ;; or 'both
-  (setq org-clock-frame-title-format
-    '((:eval (format \"%s\" org-mode-line-string))))
-
-Recommended keybindings:
-  (global-set-key (kbd \"C-<f11>\") 'org-clock-goto)
-  (define-key org-mode-map (kbd \"<f11>\") 'org-onit-toggle-doing)
-  (define-key org-mode-map (kbd \"M-<f11>\") 'org-onit-toggle-auto)
-  (define-key org-mode-map (kbd \"S-<f11>\") 'org-onit-goto-anchor)
-"
-  :init-value nil
-  :lighter (:eval (org-onit--lighter))
-  :require 'org-clock
-  :group 'org-onit
-  (if org-onit-mode
-      (org-onit--setup)
-    (org-onit--abort)))
 
 (provide 'org-onit)
 

--- a/org-onit.el
+++ b/org-onit.el
@@ -54,8 +54,7 @@
 ;;; Code:
 
 (require 'org-clock)
-(require 'bookmark nil t)
-(bookmark-maybe-load-default-file)
+(require 'bookmark)
 
 (defgroup org-onit nil
   "Commands to toggle `org-clock-in' and `org-clock-out'."
@@ -329,6 +328,9 @@ SELECT is the optional argument of `org-clock-goto'."
 
 (defun org-onit--setup ()
   "Setup."
+  ;; For bookmark.el
+  (bookmark-maybe-load-default-file)  
+  
   ;; For buffer-local
   (make-local-variable 'org-onit-basic-options)
 

--- a/org-onit.el
+++ b/org-onit.el
@@ -7,7 +7,7 @@
 ;; Version: 1.0.9
 ;; Maintainer: Takaaki ISHIKAWA <takaxp at ieee dot org>
 ;; URL: https://github.com/takaxp/org-onit
-;; Package-Requires: ((emacs "25.1"))
+;; Package-Requires: ((emacs "25.1") (org "9.2.4"))
 ;; Twitter: @takaxp
 
 ;; This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
Hi!

I fix `package-lint` warnings to add MELPA!

### Before
``` emacs-lisp
 org-oni…   222  31 warning         org-get-tags called with 2 arguments, but accepts only 0 (emacs-lisp)
 org-oni…   251  14 warning         reference to free variable ‘org-onit-mode’ (emacs-lisp)
 org-oni…   293   8 warning         ‘show-children’ is an obsolete function (as of 25.1); use ‘outline-show-children’ instead. (emacs-lisp)
 org-oni…   396  11 warning         reference to free variable ‘org-onit-mode’ (emacs-lisp)
 org-oni…   422  13 warning         reference to free variable ‘org-onit-mode’ (emacs-lisp)
 org-oni…   436   6 warning         ‘redraw-modeline’ is an obsolete function (as of 24.3); use ‘force-mode-line-update’ instead. (emacs-lisp)
 org-oni…   444  13 warning         reference to free variable ‘org-onit-mode’ (emacs-lisp)
 org-oni…   480  13 warning         reference to free variable ‘org-onit-mode’ (emacs-lisp)
 org-oni…   529   1 warning         the following functions are not known to be defined: bookmark-maybe-load-default-file, bookmark-get-bookmark (emacs-lisp)
```

### After
``` emacs-lisp
 org-oni…   223  31 warning         org-get-tags called with 2 arguments, but accepts only 0 (emacs-lisp)
```

### Note
- I think error related `org-get-tags` is wrong. The latest org definition is not reflected.
- There are `require` safe block for `bookmark`, but because Emacs-25.1 bundled it we remove the safe block.
  (But this fix is too hasty, any suggestions welcome!)
  
  This fix below warning
  ```emacs-lisp
   org-oni…   529   1 warning         the following functions are not known to be defined: bookmark-maybe-load-default-file, bookmark-get-bookmark (emacs-lisp)
  ```