### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Main workflow
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        emacs_version:
+          - '25.1'
+          - '25.2'
+          - '25.3'
+          - '26.1'
+          - '26.2'
+          - '26.3'
+          - 'snapshot'
+        include:
+          - emacs_version: 'snapshot'
+            allow_failure: true
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-python@v1.1.1
+    - uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs_version }}
+    - uses: conao3/setup-cask@master
+
+    - name: Run tests
+      if: matrix.allow_failure != true
+      run: 'make test'
+
+    - name: Run tests (allow failure)
+      if: matrix.allow_failure == true
+      run: 'make test || true'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+## .gitignore
+
+*-autoloads.el
+*.elc
+/.cask

--- a/Cask
+++ b/Cask
@@ -1,0 +1,11 @@
+;;; Cask
+
+(source org)
+(source gnu)
+(source melpa)
+
+(package-file "org-onit.el")
+
+(development
+ (depends-on "org-plus-contrib")        ; fetch latest `org'
+ (depends-on "buttercup"))

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,73 @@
+## Makefile
+
+# Copyright (C) 2019  Naoya Yamashita
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+all:
+
+REPO_USER    := takaxp
+PACKAGE_NAME := org-onit
+REPO_NAME    := org-onit
+
+EMACS        ?= emacs
+ELS          := $(shell cask files)
+
+GIT_HOOKS    := pre-commit
+
+##################################################
+
+.PHONY: all git-hook help build test clean
+
+all: git-hook help
+
+git-hook: $(GIT_HOOKS:%=.git/hooks/%)
+
+.git/hooks/%: git-hooks/%
+	cp -a $< $@
+
+help:
+	$(info )
+	$(info Commands)
+	$(info ========)
+	$(info   - make          # Install git-hook to your local .git folder)
+	$(info   - make build    # Compile elisp files)
+	$(info   - make test     # Conpile elisp files and test $(PACKAGE_NAME))
+	$(info )
+	$(info Cleaning)
+	$(info ========)
+	$(info   - make clean    # Clean compiled and fetched files)
+	$(info )
+	$(info This Makefile required `cask`)
+	$(info See https://github.com/$(REPO_USER)/$(REPO_NAME)#contribution)
+	$(info )
+
+##############################
+
+%.elc: %.el .cask
+	cask exec $(EMACS) -Q --batch -f batch-byte-compile $<
+
+.cask: Cask
+	cask install
+	touch $@
+
+##############################
+
+build: $(ELS:%.el=%.elc)
+
+test: build
+	cask exec buttercup -L .
+
+clean:
+	rm -rf $(ELS:%.el=%.elc) .cask

--- a/README.org
+++ b/README.org
@@ -151,6 +151,42 @@ Use =M-x org-onit-toggle-auto=. Toggling =org-clock-in= and =org-clock-out= will
      (org-show-siblings))
    (add-hook 'org-onit-after-jump-hook #'my-onit-reveal)
    #+end_src
+
+* Contribution
+** Require tools for testing
+- cask
+  - install via brew
+    #+begin_src shell
+      brew install cask
+    #+end_src
+
+  - manual install
+    #+begin_src shell
+      cd ~/
+      hub clone cask/cask
+      export PATH="$HOME/.cask/bin:$PATH"
+    #+end_src
+
+** Running test
+Below operation flow is recommended.
+#+begin_src shell
+  make                              # Install git-hooks in local .git
+
+  git branch [feature-branch]       # Create branch named [feature-branch]
+  git checkout [feature-branch]     # Checkout branch named [feature-branch]
+
+  # <edit loop>
+  emacs org-onit.el                 # Edit something you want
+
+  make test                         # Test org-onit
+  git commit -am "brabra"           # Commit (auto-run test before commit)
+  # </edit loop>
+
+  hub fork                          # Create fork at GitHub
+  git push [user] [feature-branch]  # Push feature-branch to your fork
+  hub pull-request                  # Create pull-request
+#+end_src
+
 * ChangeLog
  - 1.0.7 (2019-09-30)
    - [new] =org-onit-update-options= is added to update =org-onit-basic-options=

--- a/README.org
+++ b/README.org
@@ -1,6 +1,8 @@
 #+title: org-onit.el
 #+startup: showall
 
+[[https://github.com/takaxp/org-onit/actions][https://github.com/takaxp/org-onit/workflows/Main%20workflow/badge.svg]]
+
 * Introduction
 
 This package provides automated ~org-clock-in~ and ~org-clock-out~ by adding ~Doing~ tag to a heading of an org mode buffer. While the ~Doing~ tag appears in an org buffer, Emacs Org mode maintains the task clocking.

--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make test -j8

--- a/tests/org-onit-test.el
+++ b/tests/org-onit-test.el
@@ -1,0 +1,51 @@
+;;; org-onit-test.el --- Test definitions for org-onit  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2019-2020 Takaaki ISHIKAWA
+
+;; Author: Naoya Yamashita <conao3@gmail.com>
+;; URL: https://github.com/takaxp/org-onit
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs; see the file COPYING.  If not, write to the
+;; Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+;; Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; Test definitions for `org-onit'.
+
+
+;;; Code:
+
+(require 'buttercup)
+(require 'org-onit)
+
+(defconst org-onit-test-dir (file-name-directory
+                            (cond
+                             (load-in-progress load-file-name)
+                             ((and (boundp 'byte-compile-current-file)
+                                   byte-compile-current-file)
+                              byte-compile-current-file)
+                             (:else (buffer-file-name)))))
+
+(describe "A suite"
+  (it "contains a spec with an expectation"
+    (expect t :to-be t)))
+
+;; (provide 'org-onit-test)
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:
+
+;;; org-onit-test.el ends here


### PR DESCRIPTION
Hi!

I added CI scheme via GitHub Actions.

The current test file is a dummy file, but it is worth introducing CI just to see if you can **really** byte compile.
By confirming that byte compiling is possible, it is possible to prevent merging PR that contains fatal flaws as elisp files such as missing parentheses.